### PR TITLE
Adding extra options and increasing reproducibility

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/make-dockerfile
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v1
       -
         name: Lint Dockerfile
-        uses: brpaz/hadolint-action@v2.1.0
+        uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: Dockerfile
       -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: Dockerfile
-    -
+      -
         name: Docker Meta
         id: meta
         uses: docker/metadata-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/make-dockerfile
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v1
+      -
+        name: Lint Dockerfile
+        uses: brpaz/hadolint-action@v2.1.0
+        with:
+          dockerfile: Dockerfile
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push image to DockerHub
+        uses: docker/build-push-action@v3.2.0
+        with:
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/suscovont:${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/make-dockerfile
 
 jobs:
   push_to_registry:
@@ -18,6 +19,19 @@ jobs:
         uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: Dockerfile
+    -
+        name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ secrets.DOCKER_USERNAME }}/suscovont
+          tags: |
+            latest
+            type=sha,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
       -
         name: Login to DockerHub
         uses: docker/login-action@v2.1.0
@@ -29,4 +43,4 @@ jobs:
         uses: docker/build-push-action@v3.2.0
         with:
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/suscovont:${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN mamba env create --prefix /conda_for_covid/work/conda/artic-2c6f8ebeb615d37e
 # Get primer schemes
 RUN git clone https://github.com/markus-soma/primer-schemes.git
 WORKDIR /primer-schemes
-RUN git reset --hard $primer_schemes_sha
+RUN git checkout $primer_schemes_sha
 WORKDIR /
 
 # Change config file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+FROM ubuntu:20.04
+
+# Versions
+# NB! Nextflow must be without the v prefix
+ARG nextflow_ver="21.10.6"
+ARG miniconda_sh="Miniconda3-py38_4.12.0-Linux-x86_64.sh"
+ARG ncov_artic_ver="v1.3.0"
+ARG artic_ver="1.2.3"
+ARG primer_schemes_sha="9b533c7c29c3f08ec673aef6beced8ce98266267"
+
+# Copy the files we need from our repo
+WORKDIR /
+COPY LICENSE  README.md susCovONT.py* ./
+COPY ./scripts/ ./scripts/
+
+# Setting bash as shell
+SHELL ["/bin/bash", "-c"]
+
+# Installing everything we need
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=Europe/Oslo
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+    git=1:2.25.1-1ubuntu3.6 \
+    ca-certificates=20211016~20.04.1 \
+    python3=3.8.2-0ubuntu2 \
+    openjdk-8-jre=8u342-b07-0ubuntu1~20.04 \
+    wget=1.20.3-1ubuntu2 \
+    docker.io=20.10.12-0ubuntu2~20.04.1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Installing nextflow
+RUN wget -q -O nextflow https://github.com/nextflow-io/nextflow/releases/download/v${nextflow_ver}/nextflow-${nextflow_ver}-all && \
+    bash nextflow && \
+    chmod +x nextflow && \
+    mv nextflow /bin
+
+# Installing conda and mamba
+ENV PATH=$PATH:/miniconda/bin
+RUN wget -q -O miniconda.sh https://repo.anaconda.com/miniconda/$miniconda_sh && \
+    bash miniconda.sh -b -p /miniconda && \
+    rm miniconda.sh && \
+    conda install -y mamba=0.15.3 -n base -c conda-forge \
+    && mamba clean -a
+
+# Installing the conda stuff that we want
+RUN mamba install -y \
+    biopython=1.78 \
+    pandas=1.4.3 \
+    numpy=1.23.1 \
+    matplotlib=3.5.2 \
+    && mamba install -y -c bioconda \
+    samtools=1.6 \
+    && mamba install -y -c bioconda -c conda-forge -c defaults \
+    pangolin=4.1.3 \
+    && mamba clean -a
+
+# Setting up ncov2019-artic-nf pipeline and artic
+RUN git clone -b $ncov_artic_ver https://github.com/connor-lab/ncov2019-artic-nf && \
+    sed -i.bak "s/artic=1.1.3/artic=$artic_ver/g" /ncov2019-artic-nf/environments/nanopore/environment.yml && \
+    cp /scripts/articQC.py /ncov2019-artic-nf/bin/qc.py
+RUN mamba env create --prefix /conda_for_covid/work/conda/artic-2c6f8ebeb615d37ee3372e543ec21891 -f /ncov2019-artic-nf/environments/nanopore/environment.yml \
+    && mamba clean -a
+
+# Get primer schemes
+RUN git clone https://github.com/markus-soma/primer-schemes.git
+WORKDIR /primer-schemes
+RUN git reset --hard $primer_schemes_sha
+WORKDIR /
+
+# Change config file
+RUN sed -i.bak "s|^nf_location = .*|nf_location = /ncov2019-artic-nf/|" /scripts/config.cfg && \
+    sed -i.bak "s|^conda_location = .*|conda_location = /conda_for_covid/work/conda/|" /scripts/config.cfg && \
+    sed -i.bak "s|^schemeRepoURL = .*|schemeRepoURL = /primer-schemes/|" /scripts/config.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=Europe/Oslo
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends \
-    git=1:2.25.1-1ubuntu3.6 \
-    ca-certificates=20211016~20.04.1 \
+    git=1:2.25.1-1ubuntu3.10 \
+    ca-certificates=20211016ubuntu0.20.04.1 \
     python3=3.8.2-0ubuntu2 \
-    openjdk-8-jre=8u342-b07-0ubuntu1~20.04 \
+    openjdk-8-jre=8u352-ga-1~20.04 \
     wget=1.20.3-1ubuntu2 \
     docker.io=20.10.12-0ubuntu2~20.04.1 \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,11 @@ RUN mamba install -y \
 RUN git clone -b $ncov_artic_ver https://github.com/connor-lab/ncov2019-artic-nf && \
     sed -i.bak "s/artic=1.1.3/artic=$artic_ver/g" /ncov2019-artic-nf/environments/nanopore/environment.yml && \
     cp /scripts/articQC.py /ncov2019-artic-nf/bin/qc.py
-RUN mamba env create --prefix /conda_for_covid/work/conda/artic-2c6f8ebeb615d37ee3372e543ec21891 -f /ncov2019-artic-nf/environments/nanopore/environment.yml \
+RUN mamba env create --prefix /conda_for_covid/work/conda/artic-d6bee2bdeda54d67a6a5121cb8a4e56c -f /ncov2019-artic-nf/environments/nanopore/environment.yml \
     && mamba clean -a
+RUN mamba env create --prefix /conda_for_covid/work/conda/extras-65030c652c1e6445a0e32644470c48ee -f /ncov2019-artic-nf/environments/extras.yml \
+    && mamba clean -a
+
 
 # Get primer schemes
 RUN git clone https://github.com/markus-soma/primer-schemes.git

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ The Dockerimage is made to be used with Docker-out-of-Docker (DooD), where we mo
 Assuming you have the sample_names.csv file in your `<run_name>` folder:
 
 ``` shell
-docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /absolute/path/to/<run_name>:/absolute/path/to/<run_name>
-cov:test python susCovONT.py --yes --user_id 0 --input_dir /absolute/path/to/<run_name> --sample_names /absolute/path/to/<run_name>/sample_names.csv
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /absolute/path/to/<run_name>:/absolute/path/to/<run_name> tinytyranid/suscovont:latest python susCovONT.py --yes --user_id 0 --input_dir /absolute/path/to/<run_name> --sample_names /absolute/path/to/<run_name>/sample_names.csv
 ```
 
 Where:

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The barcode column can take values following the format barcode[0-9][0-9] or NB[
 
 Note: Basecalling and demultiplexing may also be performed if not already done on GridION/MinIT.
 
-## Basic usage using Dockerfile/image
+## Basic usage using Dockerimage
 
-The Dockerfile/image is made to be used with Docker-out-of-Docker (DooD), where we mount `/var/run/docker.sock` into our container and our container will start new containers that are "siblings" to the one we started it from, and thus runs them in the context of the host. Due to this we have to use absolute paths when mounting volumes and setting `--input_dir` and `--sample_names`. 
+The Dockerimage is made to be used with Docker-out-of-Docker (DooD), where we mount `/var/run/docker.sock` into our container and our container will start new containers that are "siblings" to the one we started it from, and thus runs them in the context of the host. Due to this we have to use absolute paths when mounting volumes and setting `--input_dir` and `--sample_names`. 
 
 Assuming you have the sample_names.csv file in your `<run_name>` folder:
 
@@ -50,7 +50,9 @@ Where:
 * `--user_id`: User id used to run docker commands (default: 1000), here we want to use 0 for root. 
 * `--input_dir` and `--sample_names` are described above
 
-For increased reproducibility also consider specifying the Nextclade version with `--nextclade_ver`. Pangolin version used can be found in the generated report (and later be specified in the Dockerfile and then be run with `--keep_pangolin_ver` to run the pipeline without updating Pangolin) and Nextclade database version used can be found in the output folder `005_nextclade/nextclade-tag.json` (and later be specified with `--nextclade_data_ver`). Please note that the Nextclade version is currently not recorded, so it is recommended to set this with `--nextclade_ver` if staying in control of the version is important for your use case.
+For increased reproducibility also consider specifying the Nextclade version with `--nextclade_ver` option.
+
+If one would like to rerun a data set with the pipeline with the same Pangolin version, the version used for in the original run can be found the the generated report. This version should be specified in the Dockerfile, the image rebuilt and the pipeline rerun with the `--keep_pangolin_ver` option to avoid updating Pangolin. The Nextclade database version can be found in the output file `005_nextclade/nextclade-tag.json` and be specified with `--nextclade_data_ver` option. Please note that the Nextclade version is currently not recorded, so it is recommended to set this with `--nextclade_ver` option if staying in control of the version is important for your use case.
 
 ## Please see the wiki for more information:
 * [What does the pipeline do?](https://github.com/marithetland/covid-genomics/wiki/What-does-it-do%3F)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ The barcode column can take values following the format barcode[0-9][0-9] or NB[
 
 Note: Basecalling and demultiplexing may also be performed if not already done on GridION/MinIT.
 
+## Basic usage using Dockerfile/image
+
+The Dockerfile/image is made to be used with Docker-out-of-Docker (DooD), where we mount `/var/run/docker.sock` into our container and our container will start new containers that are "siblings" to the one we started it from, and thus runs them in the context of the host. Due to this we have to use absolute paths when mounting volumes and setting `--input_dir` and `--sample_names`. 
+
+Assuming you have the sample_names.csv file in your `<run_name>` folder:
+
+``` shell
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /absolute/path/to/<run_name>:/absolute/path/to/<run_name>
+cov:test python susCovONT.py --yes --user_id 0 --input_dir /absolute/path/to/<run_name> --sample_names /absolute/path/to/<run_name>/sample_names.csv
+```
+
+Where:
+* `--yes`: Will run the pipeline non-interactively and give an automatic yes to all prompts
+* `--user_id`: User id used to run docker commands (default: 1000), here we want to use 0 for root. 
+* `--input_dir` and `--sample_names` are described above
+
+For increased reproducibility also consider specifying the Nextclade version with `--nextclade_ver`. Pangolin version used can be found in the generated report (and later be specified in the Dockerfile and then be run with `--keep_pangolin_ver` to run the pipeline without updating Pangolin) and Nextclade database version used can be found in the output folder `005_nextclade/nextclade-tag.json` (and later be specified with `--nextclade_data_ver`). Please note that the Nextclade version is currently not recorded, so it is recommended to set this with `--nextclade_ver` if staying in control of the version is important for your use case.
+
 ## Please see the wiki for more information:
 * [What does the pipeline do?](https://github.com/marithetland/covid-genomics/wiki/What-does-it-do%3F)
 * [How to run](https://github.com/marithetland/covid-genomics/wiki/1.-How-to-run)

--- a/scripts/config.cfg
+++ b/scripts/config.cfg
@@ -3,13 +3,13 @@
 
 [NF_LOCATION]
 #This is the directory you clone from: https://github.com/connor-lab/ncov2019-artic-nf
-nf_location = /home/camije/Code/susCovONT-stuffs//ncov2019-artic-nf/
+nf_location = /home/marit/Programs/ncov2019-artic-nf/
 
 [CONDA_LOCATION]
 #This is where the conda environment (with the specified artic version) is installed. See installation notes.
-conda_location = /home/camije/Code/susCovONT-stuffs//conda_for_covid/work/conda/
+conda_location = /home/marit/Programs/conda_for_covid/work/conda/
 
 [OFFLINE]
 #First download the repo when online, and then specify its path to run offline
 #This is the directory you clone from: git clone https://github.com/artic-network/primer-schemes.git
-schemeRepoURL = /home/camije/Code/susCovONT-stuffs//primer-schemes/
+schemeRepoURL = /home/marit/Programs/conda_for_covid/work/conda/

--- a/scripts/config.cfg
+++ b/scripts/config.cfg
@@ -12,4 +12,4 @@ conda_location = /home/marit/Programs/conda_for_covid/work/conda/
 [OFFLINE]
 #First download the repo when online, and then specify its path to run offline
 #This is the directory you clone from: git clone https://github.com/artic-network/primer-schemes.git
-schemeRepoURL = /home/marit/Programs/conda_for_covid/work/conda/
+schemeRepoURL = /home/marit/Programs/primer-schemes/

--- a/scripts/config.cfg
+++ b/scripts/config.cfg
@@ -3,13 +3,13 @@
 
 [NF_LOCATION]
 #This is the directory you clone from: https://github.com/connor-lab/ncov2019-artic-nf
-nf_location = /home/marit/Programs/ncov2019-artic-nf/
+nf_location = /home/camije/Code/susCovONT-stuffs//ncov2019-artic-nf/
 
 [CONDA_LOCATION]
 #This is where the conda environment (with the specified artic version) is installed. See installation notes.
-conda_location = /home/marit/Programs/conda_for_covid/work/conda/
+conda_location = /home/camije/Code/susCovONT-stuffs//conda_for_covid/work/conda/
 
 [OFFLINE]
 #First download the repo when online, and then specify its path to run offline
 #This is the directory you clone from: git clone https://github.com/artic-network/primer-schemes.git
-schemeRepoURL = /home/marit/Programs/primer-schemes/
+schemeRepoURL = /home/camije/Code/susCovONT-stuffs//primer-schemes/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,7 +109,7 @@ bash -c "source activate pangolin ; conda activate pangolin ; python setup.py in
 ## Pull nextclade image
 echo "##### Pulling nextclade (uses docker)"
 cd $INSTALL_DIR
-docker pull nextstrain/nextclade:1.11.0
+docker pull nextstrain/nextclade:2.5.0
 
 ## Change config file
 echo "##### Updating paths in file ${INSTALL_DIR}/susCovONT/scripts/config.cfg"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,8 +82,10 @@ mkdir $CONDA_LOCATION
 if testcmd mamba ; then
     echo "Found mamba, this will speed up the installation."
     mamba env create --prefix ${CONDA_LOCATION}/work/conda/artic-d6bee2bdeda54d67a6a5121cb8a4e56c --file ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml
+    mamba env create --prefix ${CONDA_LOCATION}/work/conda/extras-65030c652c1e6445a0e32644470c48ee -f ${INSTALL_DIR}/environments/extras.yml
 else
     conda env create --prefix ${CONDA_LOCATION}/work/conda/artic-d6bee2bdeda54d67a6a5121cb8a4e56c --file ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml
+    conda env create --prefix ${CONDA_LOCATION}/work/conda/extras-65030c652c1e6445a0e32644470c48ee -f ${INSTALL_DIR}/environments/extras.yml
 fi
 
 ## Download primer schemes to be used in offline mode

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,11 +70,11 @@ esac
 echo "##### Cloning artic nextflow pipeline to ${INSTALL_DIR}/ncov2019-artic-nf"
 cd $INSTALL_DIR
 git clone -b v1.3.0 https://github.com/connor-lab/ncov2019-artic-nf
-sed -i.bak 's/artic=1.1.3/artic=1.2.2/g' ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml #Change "1.2.1" to desired artic version
+sed -i.bak 's/artic=1.1.3/artic=1.2.3/g' ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml #Change "1.1.3" to desired artic version
 cp ${INSTALL_DIR}/susCovONT/scripts/articQC.py ncov2019-artic-nf/bin/qc.py #Update the QC script with the one from this repository.
 
 ## Create conda env to use as --cache for nextflow pipeline
-echo "##### Creating conda environment with artic v1.2.2 (uses conda)"
+echo "##### Creating conda environment with artic v1.2.3 (uses conda)"
 echo "##### Bear with us, this takes a little while..."
 cd $INSTALL_DIR
 CONDA_LOCATION=$(echo "${INSTALL_DIR}/conda_for_covid/") #Change this to match your system

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,12 +69,12 @@ esac
 ## Git clone artic nextflow pipeline
 echo "##### Cloning artic nextflow pipeline to ${INSTALL_DIR}/ncov2019-artic-nf"
 cd $INSTALL_DIR
-git clone https://github.com/connor-lab/ncov2019-artic-nf
-sed -i.bak 's/artic=1.1.3/artic=1.2.1/g' ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml #Change "1.2.1" to desired artic version
+git clone -b v1.3.0 https://github.com/connor-lab/ncov2019-artic-nf
+sed -i.bak 's/artic=1.1.3/artic=1.2.2/g' ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml #Change "1.2.1" to desired artic version
 cp ${INSTALL_DIR}/susCovONT/scripts/articQC.py ncov2019-artic-nf/bin/qc.py #Update the QC script with the one from this repository.
 
 ## Create conda env to use as --cache for nextflow pipeline
-echo "##### Creating conda environment with artic v1.2.1 (uses conda)"
+echo "##### Creating conda environment with artic v1.2.2 (uses conda)"
 echo "##### Bear with us, this takes a little while..."
 cd $INSTALL_DIR
 CONDA_LOCATION=$(echo "${INSTALL_DIR}/conda_for_covid/") #Change this to match your system
@@ -96,7 +96,7 @@ git clone https://github.com/markus-soma/primer-schemes.git
 ## Install pangolin
 echo "##### Installing pangolin (uses conda)"
 cd $INSTALL_DIR
-git clone https://github.com/cov-lineages/pangolin.git
+git clone -b v4.1.2 https://github.com/cov-lineages/pangolin.git
 cd ${INSTALL_DIR}/pangolin
 if testcmd mamba ; then
     echo "Found mamba, this will speed up the installation."
@@ -109,7 +109,7 @@ bash -c "source activate pangolin ; conda activate pangolin ; python setup.py in
 ## Pull nextclade image
 echo "##### Pulling nextclade (uses docker)"
 cd $INSTALL_DIR
-docker pull nextstrain/nextclade
+docker pull nextstrain/nextclade:1.11.0
 
 ## Change config file
 echo "##### Updating paths in file ${INSTALL_DIR}/susCovONT/scripts/config.cfg"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,9 +81,9 @@ CONDA_LOCATION=$(echo "${INSTALL_DIR}/conda_for_covid/") #Change this to match y
 mkdir $CONDA_LOCATION
 if testcmd mamba ; then
     echo "Found mamba, this will speed up the installation."
-    mamba env create --prefix ${CONDA_LOCATION}/work/conda/artic-2c6f8ebeb615d37ee3372e543ec21891 --file ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml
+    mamba env create --prefix ${CONDA_LOCATION}/work/conda/artic-d6bee2bdeda54d67a6a5121cb8a4e56c --file ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml
 else
-    conda env create --prefix ${CONDA_LOCATION}/work/conda/artic-2c6f8ebeb615d37ee3372e543ec21891 --file ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml
+    conda env create --prefix ${CONDA_LOCATION}/work/conda/artic-d6bee2bdeda54d67a6a5121cb8a4e56c --file ${INSTALL_DIR}/ncov2019-artic-nf/environments/nanopore/environment.yml
 fi
 
 ## Download primer schemes to be used in offline mode

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -439,7 +439,7 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_outdir,cpus,offline,d
     #get_nextclade_refs = []
     nextclade_command = []
     if not offline:
-        nextclade_command = ['docker pull nextstrain/nextclade ; '] 
+        nextclade_command = ['docker pull nextstrain/nextclade:1.11.0 ; ']
 
     nextclade_command += ['docker run --rm -u 1000' #Note this is not always 1000, use 'id -u' to find correct id
                      ' --volume="',consensus_dir, 

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -811,8 +811,11 @@ def main():
     print("Your barcodes are specified in: " + os.path.abspath(args.sample_names))
     print("And the sequencing summary txt file is: " + os.path.abspath(sequencing_summary))
     print("The primer kit is: " + primer_kit)
+    print("User id used for docker is: " + str(args.user_id))
 
     pipeline_commmand = ['The susCovONT pipeline will: ']
+    if args.yes:
+        pipeline_commmand += ['\n- run non-interactively and answer yes to all prompts']
     if args.basecalling_model:
         pipeline_commmand += ['\n- run basecalling with model', args.basecalling_model.lower()] 
     if args.barcode_kit:
@@ -826,7 +829,11 @@ def main():
     if args.generate_report_only:
         pipeline_commmand += ['\n- only (re)create output report from already completed pipeline run'] 
     if args.offline:
-        pipeline_commmand += ['\n- in offline mode'] 
+        pipeline_commmand += ['\n- in offline mode']
+    if not (args.offline and args.nextclade_ver=='latest'):
+        pipeline_commmand += ['\n- use nextclade version:',str(args.nextclade_ver)]
+    if args.keep_pangolin_ver:
+        pipeline_commmand += ['\n- keep (i.e. not update) the pangolin version']
     if args.dry_run:
         pipeline_commmand += ['\n- in dry mode (no execution of commands)'] 
     if not args.dry_run and not args.generate_report_only:

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -468,8 +468,7 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_ver,nextclade_data_ve
                      ' --output-csv=\'/seq/nextclade.csv\''
                      ' --output-all=seq/data/nextclade'
                      ' --jobs=',str(cpus),' ; '
-                     'mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,
-                     ' & >> ',nextclade_outdir,'nextclade_log.txt ; '
+                     'mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,' ; '
                      'mv ',consensus_dir,'data/nextclade ',nextclade_outdir,' ; ']
 
     #Move tag file to record which nextclade database tag/version was used

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -83,17 +83,17 @@ def parse_args():
     basecalling_args.add_argument('--guppy_use_cpu', action='store_true', required=False, help='This flag can be used with --basecalling to run on CPU instead of GPU. Will use 4 threads and 6 callers. Default: GPU -auto x.')
 
     #Advanced options
-    advanced_args.add_argument('-y', '--yes', action='store_true', help='Will run the pipeline non-interactively and give an automatic yes to all prompts.')
+    advanced_args.add_argument('-y', '--yes', action='store_true', help='Will run the pipeline non-interactively and give an automatic yes to all prompts. Default: off')
     advanced_args.add_argument('-p','--primer_kit', type=str, required=False, choices=['V4','V3','V4.1'], help='Specify primer kit: Default V4, options V3, V4 or V4.1.') #NEW
     advanced_args.add_argument('--normalise', type=int, default=500, required=False, help='Specify normalise value for artic minion. Default: 500')
     advanced_args.add_argument('--cpu', type=int, default=20, required=False, help='Specify cpus to use. Default: 20')
     advanced_args.add_argument('--nextclade_ver', type=str, default="latest", required=False, help='Set nextstrain/nextclade version that will be pulled if online. Default: latest')
     advanced_args.add_argument('-u', '--user_id', type=int, default=1000, required=False, help='User id used to run docker commands, use "id -u" to find correct id. Default: 1000')
     advanced_args.add_argument('--generate_report_only', action='store_true', required=False, help='Do not run any tools, just (re)generate output report from already completed run. Default: off.')
-    advanced_args.add_argument('--offline', action='store_true', required=False, help='The script downloads the newest primer schemes, nextclade (but see --nextclade_version) and pangolin each time it runs. Use this flag if you want to run offline with already installed versions.fault: off.')
+    advanced_args.add_argument('--offline', action='store_true', required=False, help='The script downloads the newest primer schemes, nextclade (but see --nextclade_version) and pangolin each time it runs. Use this flag if you want to run offline with already installed versions. Default: off.')
     advanced_args.add_argument('--no_move_files', action='store_true', required=False, help='By default, the input fast5_pass and fastq_pass dirs will be moved to subdir 001_rawData. Use this flag if you do not want that')
     advanced_args.add_argument('--no_artic', action='store_true', required=False, help='Use this flag to run only pangolin and nextclade on an already completed artic nextflow (with same folder structure)')
-    advanced_args.add_argument('--renormalise', type=str, required=False, choices=["on","off"], default="off", help='Turn on/off re-running artic minion with normalise 0 for samples w 90-97 perc coverage. Default=off.')
+    advanced_args.add_argument('--renormalise', type=str, required=False, choices=["on","off"], default="off", help='Turn on/off re-running artic minion with normalise 0 for samples w 90-97 perc coverage. Default: off.')
     advanced_args.add_argument('--dry_run', action='store_true', required=False, help='Executes nothing. Prints the commands that would have been run in a non-dry run.')
     advanced_args.add_argument('--seq_sum_file', type=pathlib.Path, required=False, help='If the pipeline does not find the sequence sumamry file, you can specify it. Generally not needed.')
 

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -897,7 +897,7 @@ def main():
         generate_qc_report(run_name,artic_final_qc,nextclade_outfile,pangolin_outfile,sample_df,final_report_name,consensus_dir,args.renormalise,str(args.normalise))
 
     #Move input files to 001_rawData directory
-    if not args.no_move_files or not args.dry_run:
+    if not (args.no_move_files or args.dry_run):
         move_input_files(outdir,raw_data_path)
 
     #Pipeline complete

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -470,8 +470,10 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_ver,nextclade_data_ve
                      ' --jobs=',str(cpus),' ; '
                      'mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,
                      ' & >> ',nextclade_outdir,'nextclade_log.txt ; '
-                     'mv ',consensus_dir,'data/nextclade ',nextclade_outdir]
+                     'mv ',consensus_dir,'data/nextclade ',nextclade_outdir,' ; ']
 
+    #Move tag file to record which nextclade database tag/version was used
+    nextclade_command += ['mv ',consensus_dir,'/data/sars-cov-2/tag.json ',nextclade_outdir,'/nextclade-tag.json']
 
     print(combineCommand(nextclade_command))
     return nextclade_command

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -87,7 +87,7 @@ def parse_args():
     advanced_args.add_argument('-p','--primer_kit', type=str, required=False, choices=['V4','V3','V4.1'], help='Specify primer kit: Default V4.1, options V3, V4 or V4.1.') #NEW
     advanced_args.add_argument('--normalise', type=int, default=500, required=False, help='Specify normalise value for artic minion. Default: 500')
     advanced_args.add_argument('--cpu', type=int, default=20, required=False, help='Specify cpus to use. Default: 20')
-    advanced_args.add_argument('--offline', action='store_true', required=False, help='The script downloads the newest primer schemes, nextclade and pangolin each time it runs. Use this flag if you want to run offline with already installed versions. For more specific options see --nexclade_ver and --keep_pangolin_ver. Default: off.')
+    advanced_args.add_argument('--offline', action='store_true', required=False, help='The script downloads the newest nextclade and pangolin version each time it runs. Use this flag if you want to run offline with already installed versions. For more specific options see --nexclade_ver and --keep_pangolin_ver. Default: off.')
     advanced_args.add_argument('--nextclade_ver', type=str, default="latest", required=False, help='Set nextstrain/nextclade version that will be pulled if online (see also --offline). Default: latest.')
     advanced_args.add_argument('--nextclade_data_ver', type=str, default="latest", required=False, help='Set nextclade database to be used by nextclade. Default: latest.')
     advanced_args.add_argument('--keep_pangolin_ver', action='store_true', help='Will run the pipeline without updating pangolin (see also --offline). Default is updating pangolin.')

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -240,7 +240,7 @@ def set_config_variables(args):
     #Check if basecalling or demultiplexing is being performed and check that tools exist
     check_versions(conda_location,nf_dir_location,full_path)
 
-    return nf_dir_location, conda_location, schemeRepoURL#, nextclad_refdir_location
+    return nf_dir_location, conda_location, schemeRepoURL#, nextclade_refdir_location
 
 def get_sample_names(sample_names):
     """Check that the sample file exists and has correct format (try to edit if possible)"""

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -365,7 +365,7 @@ def check_input(args):
             sequencing_summary=os.path.join(fastq_pass_alt,"sequencing_summary.txt")
 
     #Check that the specified sequencing summary actually exists
-    if not args.basecalling_model or not args.barcode_kit:
+    if not (args.basecalling_model or args.barcode_kit):
         if not args.seq_sum_file:
             seq_summary=os.path.abspath(sequencing_summary)
         if args.seq_sum_file:

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -83,6 +83,7 @@ def parse_args():
     basecalling_args.add_argument('--guppy_use_cpu', action='store_true', required=False, help='This flag can be used with --basecalling to run on CPU instead of GPU. Will use 4 threads and 6 callers. Default: GPU -auto x.')
 
     #Advanced options
+    advanced_args.add_argument('-y', '--yes', action='store_true', help='Will run the pipeline non-interactively and give an automatic yes to all prompts.')
     advanced_args.add_argument('-p','--primer_kit', type=str, required=False, choices=['V4','V3','V4.1'], help='Specify primer kit: Default V4, options V3, V4 or V4.1.') #NEW
     advanced_args.add_argument('--normalise', type=int, default=500, required=False, help='Specify normalise value for artic minion. Default: 500')
     advanced_args.add_argument('--cpu', type=int, default=20, required=False, help='Specify cpus to use. Default: 20')
@@ -148,9 +149,12 @@ def check_barcodeID(value, pattern=re.compile("barcode[0-9][0-9]")):
     """Check that barcode in sample_names follows the correct pattern"""
     return 'TRUE' if pattern.match(value) else 'FALSE'
     
-def yes_or_no(question):
-    """Ask user a yes/no question"""
-    reply = str(input(question+' (y/n): ')).lower().strip()
+def yes_or_no(question, automatic_yes):
+    """Ask user a yes/no question unless automatic yes is selected"""
+    if automatic_yes:
+        reply='yes'
+    else:
+        reply = str(input(question+' (y/n): ')).lower().strip()
     if reply[0] == 'y':
         print("Starting pipeline")
         return 1
@@ -826,7 +830,7 @@ def main():
     print(listToString(pipeline_commmand))
 
     while True:
-        if(yes_or_no('Would you like to run this pipeline? y/n: ')):
+        if(yes_or_no('Would you like to run this pipeline? y/n: ', args.yes)):
             break
 
     ##Run pipeline

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -443,18 +443,22 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_version,nextclade_out
     if not Path(nextclade_outdir).is_dir():
         os.mkdir(nextclade_outdir)
     logging.info('Running nextclade with command: ')
+    if offline and nextclade_version=='latest':
+        nextclade_image = 'nextstrain/nextclade'
+    else:
+        nextclade_image = 'nextstrain/nextclade:{}'.format(nextclade_version)
     #get_nextclade_refs = []
     nextclade_command = []
     if not offline:
-        nextclade_command = ['docker pull nextstrain/nextclade:{} ; '.format(nextclade_version)]
+        nextclade_command = ['docker pull ',nextclade_image,' ; ']
 
-    nextclade_command += ['docker run --rm -u {}'.format(user_id),
-                     ' --volume="',consensus_dir, 
-                     ':/seq" nextstrain/nextclade:{} nextclade dataset get --name=sars-cov-2 --output-dir=seq/data/sars-cov-2 ; '.format(nextclade_version)]
+    nextclade_command += ['docker run --rm -u ',str(user_id),
+                     ' --volume="',consensus_dir,
+                     ':/seq" ',nextclade_image,' nextclade dataset get --name=sars-cov-2 --output-dir=seq/data/sars-cov-2 ; ']
 
-    nextclade_command += ['docker run --rm -u {}'.format(user_id),
+    nextclade_command += ['docker run --rm -u ',str(user_id),
                      ' --volume="',consensus_dir, 
-                     ':/seq" nextstrain/nextclade:{} nextclade run'.format(nextclade_version),
+                     ':/seq" ',nextclade_image,' nextclade run',
                      ' --input-dataset=\'/seq/data/sars-cov-2\''
                      ' /seq/',consensus_base,''
                      ' --output-csv=\'/seq/nextclade.csv\''

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -450,11 +450,11 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_version,nextclade_out
 
     nextclade_command += ['docker run --rm -u {}'.format(user_id),
                      ' --volume="',consensus_dir, 
-                     ':/seq" nextstrain/nextclade nextclade dataset get --name=sars-cov-2 --output-dir=seq/data/sars-cov-2 ; ']
+                     ':/seq" nextstrain/nextclade:{} nextclade dataset get --name=sars-cov-2 --output-dir=seq/data/sars-cov-2 ; '.format(nextclade_version)]
 
     nextclade_command += ['docker run --rm -u {}'.format(user_id),
                      ' --volume="',consensus_dir, 
-                     ':/seq" nextstrain/nextclade nextclade run' 
+                     ':/seq" nextstrain/nextclade:{} nextclade run'.format(nextclade_version),
                      ' --input-dataset=\'/seq/data/sars-cov-2\''
                      ' /seq/',consensus_base,''
                      ' --output-csv=\'/seq/nextclade.csv\''

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -42,6 +42,9 @@ from subprocess import call, check_output, CalledProcessError, STDOUT
 from pathlib import Path    
 from shutil import copyfile
 
+class CommandError(Exception):
+    pass
+
 #Options for basecalling and barcoding
 BASECALLING = collections.OrderedDict([
     ('r9.4_fast', ['--config dna_r9.4.1_450bps_fast.cfg ']), 
@@ -111,10 +114,10 @@ def run_command(command, **kwargs):
         exit_status = call(command_str, **kwargs)
     except OSError as e:
         message = "Command '{}' failed due to O/S error: {}".format(command_str, str(e))
-        raise CommandError({"Error:": message})
+        raise CommandError("Error: {}".format(message))
     if exit_status != 0:
         message = "Command '{}' failed with non-zero exit status: {}".format(command_str, exit_status)
-        raise CommandError({"Error:": message})
+        raise CommandError("Error: {}".format(message))
 
 def listToString(s):  
     """Join a list to string for running cmd with space delimiter"""

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -9,7 +9,7 @@
 # Created: 2021-01-24
 #
 # Prerequisites:
-#	 biopython, pandas, numpy, nextflow v20+
+#	 biopython, pandas, numpy, nextflow v20.01.0 - v21.10.6
 #
 #
 # Example command:

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -84,7 +84,7 @@ def parse_args():
 
     #Advanced options
     advanced_args.add_argument('-y', '--yes', action='store_true', help='Will run the pipeline non-interactively and give an automatic yes to all prompts. Default: off')
-    advanced_args.add_argument('-p','--primer_kit', type=str, required=False, choices=['V4','V3','V4.1'], help='Specify primer kit: Default V4, options V3, V4 or V4.1.') #NEW
+    advanced_args.add_argument('-p','--primer_kit', type=str, required=False, choices=['V4','V3','V4.1'], help='Specify primer kit: Default V4.1, options V3, V4 or V4.1.') #NEW
     advanced_args.add_argument('--normalise', type=int, default=500, required=False, help='Specify normalise value for artic minion. Default: 500')
     advanced_args.add_argument('--cpu', type=int, default=20, required=False, help='Specify cpus to use. Default: 20')
     advanced_args.add_argument('--offline', action='store_true', required=False, help='The script downloads the newest primer schemes, nextclade and pangolin each time it runs. Use this flag if you want to run offline with already installed versions. For more specific options see --nexclade_ver and --keep_pangolin_ver. Default: off.')

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -414,9 +414,6 @@ def get_nextflow_command(primer_kit, demultiplexed_fastq, fast5_pass, sequencing
                      '--schemeRepoURL ', schemeRepoURL,
                      '--schemeVersion ', primer_kit,
                      '--outdir ', nf_outdir]
-    #if offline:
-        #nextflow_command += ['--schemeRepoURL ', schemeRepoURL]  #add option for offline running
-    #nextflow_command +=['2>&1 artic_log.txt']
     print(listToString(nextflow_command))
     
     return nextflow_command

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -86,8 +86,9 @@ def parse_args():
     advanced_args.add_argument('-p','--primer_kit', type=str, required=False, choices=['V4','V3','V4.1'], help='Specify primer kit: Default V4, options V3, V4 or V4.1.') #NEW
     advanced_args.add_argument('--normalise', type=int, default=500, required=False, help='Specify normalise value for artic minion. Default: 500')
     advanced_args.add_argument('--cpu', type=int, default=20, required=False, help='Specify cpus to use. Default: 20')
+    advanced_args.add_argument('--nextclade_ver', type=str, default="latest", required=False, help='Set nextstrain/nextclade version that will be pulled if online. Default: latest')
     advanced_args.add_argument('--generate_report_only', action='store_true', required=False, help='Do not run any tools, just (re)generate output report from already completed run. Default: off.')
-    advanced_args.add_argument('--offline', action='store_true', required=False, help='The script downloads the newest primer schemes, nextclade and pangolin each time it runs. Use this flag if you want to run offline with already installed versions.fault: off.')
+    advanced_args.add_argument('--offline', action='store_true', required=False, help='The script downloads the newest primer schemes, nextclade (but see --nextclade_version) and pangoli each time it runs. Use this flag if you want to run offline with already installed versions.fault: off.')
     advanced_args.add_argument('--no_move_files', action='store_true', required=False, help='By default, the input fast5_pass and fastq_pass dirs will be moved to subdir 001_rawData. Use this flag if you do not want that')
     advanced_args.add_argument('--no_artic', action='store_true', required=False, help='Use this flag to run only pangolin and nextclade on an already completed artic nextflow (with same folder structure)')
     advanced_args.add_argument('--renormalise', type=str, required=False, choices=["on","off"], default="off", help='Turn on/off re-running artic minion with normalise 0 for samples w 90-97 perc coverage. Default=off.')
@@ -232,7 +233,7 @@ def set_config_variables(args):
     #Check if basecalling or demultiplexing is being performed and check that tools exist
     check_versions(conda_location,nf_dir_location,full_path)
 
-    return nf_dir_location, conda_location, schemeRepoURL#, nextclade_refdir_location
+    return nf_dir_location, conda_location, schemeRepoURL#, nextclad_refdir_location
 
 def get_sample_names(sample_names):
     """Check that the sample file exists and has correct format (try to edit if possible)"""
@@ -428,7 +429,7 @@ def get_pangolin_command(consensus_file,pangolin_outdir,number_CPUs,offline):
     return pangolin_command
 
 
-def get_nextclade_command(run_name,consensus_dir,nextclade_outdir,cpus,offline,dry_run):
+def get_nextclade_command(run_name,consensus_dir,nextclade_version,nextclade_outdir,cpus,offline,dry_run):
     """Get the command used for running nextclade"""
     consensus_base=(run_name+'_sequences.fasta')
     ##TODO: ADD --jobs=str(cpus) to command - check if works
@@ -439,13 +440,13 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_outdir,cpus,offline,d
     #get_nextclade_refs = []
     nextclade_command = []
     if not offline:
-        nextclade_command = ['docker pull nextstrain/nextclade:1.11.0 ; ']
+        nextclade_command = ['docker pull nextstrain/nextclade:'+nextclade_version+' ; ']
 
-    nextclade_command += ['docker run --rm -u 1000' #Note this is not always 1000, use 'id -u' to find correct id
+    nextclade_command += ['docker run --rm -u 0' #Note this is not always 1000, use 'id -u' to find correct id
                      ' --volume="',consensus_dir, 
                      ':/seq" nextstrain/nextclade nextclade dataset get --name=sars-cov-2 --output-dir=seq/data/sars-cov-2 ; ']
 
-    nextclade_command += ['docker run --rm -u 1000' #Note this is not always 1000, use 'id -u' to find correct id
+    nextclade_command += ['docker run --rm -u 0' #Note this is not always 1000, use 'id -u' to find correct id
                      ' --volume="',consensus_dir, 
                      ':/seq" nextstrain/nextclade nextclade run' 
                      ' --input-dataset=\'/seq/data/sars-cov-2\''
@@ -859,7 +860,7 @@ def main():
 
     ##Nextclade lineage assignment and substitutions
     if not args.generate_report_only:
-        nextclade_command=(get_nextclade_command(run_name,consensus_dir,nextclade_outdir,args.cpu,args.offline,args.dry_run))
+        nextclade_command=(get_nextclade_command(run_name,consensus_dir,args.nextclade_ver,nextclade_outdir,args.cpu,args.offline,args.dry_run))
         if not args.dry_run:
             run_command([combineCommand(nextclade_command)], shell=True)
         

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -195,7 +195,7 @@ def check_versions(conda_location,nf_dir_location,full_path):
     return
 
     #check_artic_version(conda_location):
-    run_command(['echo "artic \t" >> ',full_path,'/pipeline_versions.txt ; ',conda_location,'/artic-2c6f8ebeb615d37ee3372e543ec21891/bin/artic --version >> ',full_path,'/pipeline_versions.txt'], shell=True) ##Check for empty results, skip
+    run_command(['echo "artic \t" >> ',full_path,'/pipeline_versions.txt ; ',conda_location,'/artic-d6bee2bdeda54d67a6a5121cb8a4e56c/bin/artic --version >> ',full_path,'/pipeline_versions.txt'], shell=True) ##Check for empty results, skip
     pass
 
 # def check_pangolin_version():
@@ -727,7 +727,7 @@ def run_artic_minion(primer_kit, barcode,nf_outdir,cpu,schemeRepoURL,fast5_pass_
     #Get barcode path
     barcode_path=os.path.join(nf_outdir,'articNcovNanopore_sequenceAnalysisNanopolish_articGuppyPlex/')
     
-    re_normalise_command = ['bash -c "source activate ',conda_location,'artic-2c6f8ebeb615d37ee3372e543ec21891 ; ',]
+    re_normalise_command = ['bash -c "source activate ',conda_location,'artic-d6bee2bdeda54d67a6a5121cb8a4e56c ; ',]
     re_normalise_command += ['artic minion --normalise 0 --threads ', str(cpu),
                             ' --scheme-directory ', schemeRepoURL,
                             ' --read-file ', barcode_path, barcode, '.fastq'

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -467,12 +467,12 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_ver,nextclade_data_ve
                      ' /seq/',consensus_base,''
                      ' --output-csv=\'/seq/nextclade.csv\''
                      ' --output-all=seq/data/nextclade'
-                     ' --jobs=',str(cpus),' ; '
-                     'mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,' ; '
-                     'mv ',consensus_dir,'data/nextclade ',nextclade_outdir,' ; ']
+                     ' --jobs=',str(cpus),' ; ']
 
-    #Move tag file to record which nextclade database tag/version was used
-    nextclade_command += ['mv ',consensus_dir,'/data/sars-cov-2/tag.json ',nextclade_outdir,'/nextclade-tag.json']
+    #Move nextclade results and database information to the nextclade output folder
+    nextclade_command += ['mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,' ; '
+                     'mv ',consensus_dir,'data/nextclade ',nextclade_outdir,' ; '
+                     'mv ',consensus_dir,'/data/sars-cov-2/tag.json ',nextclade_outdir,'/nextclade-tag.json']
 
     print(combineCommand(nextclade_command))
     return nextclade_command


### PR DESCRIPTION
We are currently implementing the susCovONT pipeline, during this we have noticed that for us some of the tools would not work together unless they all were a specific version. We also had some need for some extra options as our goal is to automate it and at the same time increase reproducibility while doing so. 

These are the changes we have implemented:
- Version of tools that work together are specified in `install.sh` to make initial setup a bit easier
- The `tag.json` from Nextclade is now moved to retain the information of the Nextclade database/tag that was used (`005_nextclade/nextclade-tag.json`)
- We have added some extra options while running the pipeline:
    - `-y, --yes` for running the pipeline non-interactively and give an automatic yes to all prompts
    - `--nextclade_ver` for specifying the Nextclade version one would want to use
    - `--nextclade_data_ver` for specifying the Nextclade database tag that one would like to use
    - `--keep_pangolin_ver` for running the pipeline without updating Pangolin
    - `-u, --user-id` for specifying the user id for running docker commands 
    - We have also updated the help text of some of the options that were already present 
    - While adding these options we have made sure that the defaults are as they were from before, so a user that was running the pipeline before does not have to change the commands they are using now
- We have also done some small fixes that we have come across while implementing these changes
 
Thank you for the great work you have done on developing this pipeline!

**Edit 03.11.2022**
- Added Dockerfile
- Added a basic usage example using the Dockerimage
- Added actions/ci for the docker